### PR TITLE
Send test coverage data to Azure Pipelines

### DIFF
--- a/build-test-pipeline.yml
+++ b/build-test-pipeline.yml
@@ -51,3 +51,13 @@ stages:
       displayName: Run pre-commit hooks to check linting and formatting
     - script: poetry run tox -e py
       displayName: Run tests against multiple Python versions using tox
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: '**/test-*.xml'
+        testRunTitle: 'Publish test results for Python $(python.version)'
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+        reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'

--- a/poetry.lock
+++ b/poetry.lock
@@ -372,6 +372,21 @@ checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "2.11.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+coverage = ">=5.2.1"
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -524,7 +539,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<4.0"
-content-hash = "5120d553679060ceb7720a3b136c34037b4651f075e2978a0267bb2b6a77cb59"
+content-hash = "94d99f24dda5174bd05bca9897e5def146d4c08a9147447312e8c66bfaf9745c"
 
 [metadata.files]
 appdirs = [
@@ -750,6 +765,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pylint = "^2.7.4"
 coverage = "^5.5"
 httpretty = "^1.0.5"
 tox = "^3.23.0"
+pytest-cov = "^2.11.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ envlist = py36, py37, py38, py39
 whitelist_externals = poetry
 commands =
     poetry install -v
-    poetry run pytest amplitude_python_sdk/tests --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+    poetry run pytest amplitude_python_sdk/tests --junitxml=junit/test-results.xml --cov=. --cov-report=xml

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ envlist = py36, py37, py38, py39
 whitelist_externals = poetry
 commands =
     poetry install -v
-    poetry run pytest amplitude_python_sdk/tests
+    poetry run pytest amplitude_python_sdk/tests --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html


### PR DESCRIPTION
Add pytest-cov as a dev dependency, and upload coverage and test results to Azure Pipelines on CI runs.