### PR TITLE
Add pipeline step for uploading to Codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # IDE files
 .idea/
+
+# Test coverage reports
+junit/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,3 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
-      - id: run tests
-        name: run tests
-        entry: poetry run pytest amplitude_python_sdk/tests
-        language: system
-        always_run: true
-        pass_filenames: false

--- a/build-test-pipeline.yml
+++ b/build-test-pipeline.yml
@@ -59,5 +59,3 @@ stages:
     - script: |
         bash <(curl -s https://codecov.io/bash)
       displayName: 'Upload to codecov.io'
-      env:
-        CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/build-test-pipeline.yml
+++ b/build-test-pipeline.yml
@@ -56,8 +56,8 @@ stages:
       inputs:
         testResultsFiles: '**/test-*.xml'
         testRunTitle: 'Publish test results for Python $(python.version)'
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: Cobertura
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-        reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+    - script: |
+        bash <(curl -s https://codecov.io/bash)
+      displayName: 'Upload to codecov.io'
+      env:
+        CODECOV_TOKEN: $(CODECOV_TOKEN)


### PR DESCRIPTION
Codecov may be a better and simpler solution than Azure Artifacts for displaying coverage status. Test out the integration here to see if we can successfully upload reports to Codecov.